### PR TITLE
Analysis API, Documentation Updates

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ plugins:
             docstring_section_style: spacy
             show_source: false
             members_order: source
+            show_bases: false
   - with-pdf:
       output_path: onyx-client.pdf
       cover_subtitle: ""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,10 +30,8 @@ theme:
       
   features:
     - navigation.tabs
-    - navigation.tabs.sticky
-    # - navigation.sections
-    # - navigation.top
-    # - toc.integrate
+    - navigation.top
+    - navigation.sections
     - content.code.copy
 
 # extra:

--- a/onyx/__init__.py
+++ b/onyx/__init__.py
@@ -1,5 +1,7 @@
 """`~ O N Y X ~`"""
+
 from .config import OnyxConfig, OnyxEnv
 from .api import OnyxClient
 from .field import OnyxField
+from .endpoints import OnyxEndpoint
 from . import exceptions

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -257,6 +257,9 @@ class OnyxClient(OnyxClientBase):
             ```python
             >>> fields
             {
+                "name": "Project Name",
+                "description": "Project description.",
+                "object_type": "records",
                 "version": "0.1.0",
                 "fields": {
                     "climb_id": {

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -1460,7 +1460,7 @@ class OnyxClient(OnyxClientBase):
     def filter_analysis(
         self,
         project: str,
-        fields: Union[Dict[str, Any], None] = None,
+        fields: Optional[Dict[str, Any]] = None,
         include: Union[List[str], str, None] = None,
         exclude: Union[List[str], str, None] = None,
         summarise: Union[List[str], str, None] = None,

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -1401,7 +1401,7 @@ class OnyxClient(OnyxClientBase):
     def get_analysis(
         self,
         project: str,
-        analysis_id: str,
+        analysis_id: Optional[str] = None,
         fields: Optional[Dict[str, Any]] = None,
         include: Union[List[str], str, None] = None,
         exclude: Union[List[str], str, None] = None,

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -1403,8 +1403,8 @@ class OnyxClient(OnyxClientBase):
         project: str,
         analysis_id: str,
         fields: Optional[Dict[str, Any]] = None,
-        include: List[str] | str | None = None,
-        exclude: List[str] | str | None = None,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
     ) -> Dict[str, Any]:
         """
         Get an analysis from a project.
@@ -1460,10 +1460,10 @@ class OnyxClient(OnyxClientBase):
     def filter_analysis(
         self,
         project: str,
-        fields: Dict[str, Any] | None = None,
-        include: List[str] | str | None = None,
-        exclude: List[str] | str | None = None,
-        summarise: List[str] | str | None = None,
+        fields: Union[Dict[str, Any], None] = None,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+        summarise: Union[List[str], str, None] = None,
         **kwargs: Any,
     ) -> Generator[Dict[str, Any], Any, None]:
         """

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -35,7 +35,6 @@ class DefinedOrderGroup(TyperGroup):
 
 app = typer.Typer(
     name="onyx",
-    help="API for pathogen metadata.",
     cls=DefinedOrderGroup,
     no_args_is_help=True,
     pretty_exceptions_show_locals=False,
@@ -939,7 +938,6 @@ def filter_base(
     format: Optional[DataFormats],
     method: str,
 ):
-
     try:
         api = setup_onyx_api(context.obj)
 
@@ -1822,6 +1820,12 @@ def common(
         help="Show the client version number and exit.",
     ),
 ):
+    """
+    API for Pathogen Metadata.
+
+    For documentation, see: https://climb-tre.github.io/onyx-client/
+    """
+
     context.obj = OnyxConfigOptions(
         domain=domain,
         token=token,

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -672,7 +672,11 @@ def fields_base(
                 "Actions",
                 "Restrictions",
             ]
-            caption = f"Fields specification for the {fields['name']} project. Version: {fields['version']}"
+
+            if fields.get("object_type"):
+                caption = f"Fields specification for {fields['object_type']} in the {fields['name']} project. Version: {fields['version']}"
+            else:
+                caption = f"Fields specification for the {fields['name']} project. Version: {fields['version']}"
 
             if fields.get("description"):
                 caption += "\n" + fields["description"]

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -769,9 +769,9 @@ def choices_base(
             table.add_column("Status", overflow="fold")
             for choice, choice_info in choices.items():
                 active_status = choice_info.get("is_active")
-                if active_status == True:
+                if active_status:
                     active_status = ActiveStatus.ACTIVE.value
-                elif active_status == False:
+                elif active_status:
                     active_status = ActiveStatus.INACTIVE.value
                 else:
                     active_status = ""

--- a/onyx/core.py
+++ b/onyx/core.py
@@ -1,4 +1,3 @@
-import posixpath
 import csv
 import inspect
 import requests
@@ -12,362 +11,11 @@ from .exceptions import (
     OnyxRequestError,
     OnyxServerError,
 )
+from .endpoints import OnyxEndpoint
 
 
 class OnyxClientBase:
     __slots__ = "config", "_request_handler", "_session"
-    ENDPOINTS = {
-        "projects": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects/",
-            ),
-            domain=domain,
-        ),
-        "types": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects/types/",
-            ),
-            domain=domain,
-        ),
-        "lookups": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects/lookups/",
-            ),
-            domain=domain,
-        ),
-        "fields": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "fields/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "choices": lambda domain, project, field: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "choices",
-                str(field),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            field=field,
-        ),
-        "get": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                str(climb_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            climb_id=climb_id,
-        ),
-        "filter": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "query": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "query/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "history": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "history",
-                str(climb_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            climb_id=climb_id,
-        ),
-        "identify": lambda domain, project, field: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "identify",
-                str(field),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            field=field,
-        ),
-        "create": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "create.test": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "test/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "update": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                str(climb_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            climb_id=climb_id,
-        ),
-        "update.test": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "test",
-                str(climb_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            climb_id=climb_id,
-        ),
-        "delete": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                str(climb_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            climb_id=climb_id,
-        ),
-        "analysis.fields": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/fields/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "analysis.choices": lambda domain, project, field: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/choices",
-                str(field),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            field=field,
-        ),
-        "analysis.get": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis",
-                str(analysis_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            analysis_id=analysis_id,
-        ),
-        "analysis.filter": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "analysis.history": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/history",
-                str(analysis_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            analysis_id=analysis_id,
-        ),
-        "analysis.create": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "analysis.create.test": lambda domain, project: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/test/",
-            ),
-            domain=domain,
-            project=project,
-        ),
-        "analysis.update": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis",
-                str(analysis_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            analysis_id=analysis_id,
-        ),
-        "analysis.update.test": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis/test",
-                str(analysis_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            analysis_id=analysis_id,
-        ),
-        "analysis.delete": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "projects",
-                str(project),
-                "analysis",
-                str(analysis_id),
-                "",
-            ),
-            domain=domain,
-            project=project,
-            analysis_id=analysis_id,
-        ),
-        "register": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/register/",
-            ),
-            domain=domain,
-        ),
-        "login": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/login/",
-            ),
-            domain=domain,
-        ),
-        "logout": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/logout/",
-            ),
-            domain=domain,
-        ),
-        "logoutall": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/logoutall/",
-            ),
-            domain=domain,
-        ),
-        "profile": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/profile/",
-            ),
-            domain=domain,
-        ),
-        "activity": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/activity/",
-            ),
-            domain=domain,
-        ),
-        "waiting": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/waiting/",
-            ),
-            domain=domain,
-        ),
-        "approve": lambda domain, username: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/approve",
-                str(username),
-                "",
-            ),
-            domain=domain,
-            username=username,
-        ),
-        "siteusers": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/site/",
-            ),
-            domain=domain,
-        ),
-        "allusers": lambda domain: OnyxClientBase._handle_endpoint(
-            lambda: posixpath.join(
-                str(domain),
-                "accounts/all/",
-            ),
-            domain=domain,
-        ),
-    }
 
     def __init__(self, config: OnyxConfig):
         self.config = config
@@ -383,44 +31,6 @@ class OnyxClientBase:
         if self._session:
             self._session.close()
         self._request_handler = requests.request
-
-    @classmethod
-    def _handle_endpoint(cls, endpoint, **kwargs):
-        for name, val in kwargs.items():
-            if val is None or not str(val).strip():
-                raise OnyxClientError(f"Argument '{name}' was not provided.")
-
-            val = str(val).strip()
-
-            if name != "domain":
-                for char in "/?":
-                    if char in val:
-                        raise OnyxClientError(
-                            f"Argument '{name}' contains invalid character: '{char}'."
-                        )
-
-                # Crude but effective prevention of unexpectedly calling other endpoints
-                # Its not the end of the world if that did happen, but to the user it would be quite confusing
-                clashes = {
-                    "project": ["types", "lookups"],
-                    "climb_id": [
-                        "test",
-                        "query",
-                        "fields",
-                        "choices",
-                        "history",
-                        "identify",
-                    ],
-                }
-
-                if name in clashes:
-                    for clash in clashes[name]:
-                        if val == clash:
-                            raise OnyxClientError(
-                                f"Argument '{name}' cannot have value '{val}'. This creates a URL that resolves to a different endpoint."
-                            )
-
-        return endpoint()
 
     def _request(self, method: str, retries: int = 3, **kwargs) -> requests.Response:
         if not retries:
@@ -513,13 +123,9 @@ class OnyxClientBase:
                         raise OnyxClientError(
                             "Record requires a 'climb_id' for upload."
                         )
-                    url = OnyxClientBase.ENDPOINTS[endpoint](
-                        self.config.domain, project, climb_id
-                    )
+                    url = OnyxEndpoint[endpoint](self.config.domain, project, climb_id)
                 else:
-                    url = OnyxClientBase.ENDPOINTS[endpoint](
-                        self.config.domain, project
-                    )
+                    url = OnyxEndpoint[endpoint](self.config.domain, project)
 
                 response = self._request(
                     method=method,
@@ -550,28 +156,28 @@ class OnyxClientBase:
     def projects(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["projects"](self.config.domain),
+            url=OnyxEndpoint["projects"](self.config.domain),
         )
         return response
 
     def types(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["types"](self.config.domain),
+            url=OnyxEndpoint["types"](self.config.domain),
         )
         return response
 
     def lookups(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["lookups"](self.config.domain),
+            url=OnyxEndpoint["lookups"](self.config.domain),
         )
         return response
 
     def fields(self, project: str, endpoint: str = "fields") -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project),
+            url=OnyxEndpoint[endpoint](self.config.domain, project),
         )
         return response
 
@@ -580,7 +186,7 @@ class OnyxClientBase:
     ) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project, field),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, field),
         )
         return response
 
@@ -594,9 +200,7 @@ class OnyxClientBase:
     ) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS[endpoint](
-                self.config.domain, project, climb_id
-            ),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, climb_id),
             params={"include": include, "exclude": exclude},
         )
         return response
@@ -631,7 +235,7 @@ class OnyxClientBase:
             "summarise": summarise,
         }
 
-        _next = OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project)
+        _next = OnyxEndpoint[endpoint](self.config.domain, project)
 
         while _next is not None:
             response = self._request(
@@ -671,7 +275,7 @@ class OnyxClientBase:
             "exclude": exclude,
             "summarise": summarise,
         }
-        _next = OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project)
+        _next = OnyxEndpoint[endpoint](self.config.domain, project)
 
         while _next is not None:
             response = self._request(
@@ -732,9 +336,7 @@ class OnyxClientBase:
     ) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS[endpoint](
-                self.config.domain, project, climb_id
-            ),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, climb_id),
         )
         return response
 
@@ -752,7 +354,7 @@ class OnyxClientBase:
 
         response = self._request(
             method="post",
-            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project, field),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, field),
             json=identify_json,
         )
         return response
@@ -769,7 +371,7 @@ class OnyxClientBase:
 
         response = self._request(
             method="post",
-            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project),
+            url=OnyxEndpoint[endpoint](self.config.domain, project),
             json=fields,
         )
         return response
@@ -787,9 +389,7 @@ class OnyxClientBase:
 
         response = self._request(
             method="patch",
-            url=OnyxClientBase.ENDPOINTS[endpoint](
-                self.config.domain, project, climb_id
-            ),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, climb_id),
             json=fields,
         )
         return response
@@ -802,9 +402,7 @@ class OnyxClientBase:
     ) -> requests.Response:
         response = self._request(
             method="delete",
-            url=OnyxClientBase.ENDPOINTS[endpoint](
-                self.config.domain, project, climb_id
-            ),
+            url=OnyxEndpoint[endpoint](self.config.domain, project, climb_id),
         )
         return response
 
@@ -982,7 +580,7 @@ class OnyxClientBase:
         password: str,
     ) -> requests.Response:
         response = requests.post(
-            OnyxClientBase.ENDPOINTS["register"](domain),
+            OnyxEndpoint["register"](domain),
             json={
                 "first_name": first_name,
                 "last_name": last_name,
@@ -1002,7 +600,7 @@ class OnyxClientBase:
         response = self._request_handler(
             "post",
             auth=credentials,
-            url=OnyxClientBase.ENDPOINTS["login"](self.config.domain),
+            url=OnyxEndpoint["login"](self.config.domain),
         )
         if response.ok:
             self.config.token = response.json()["data"]["token"]
@@ -1012,7 +610,7 @@ class OnyxClientBase:
     def logout(self) -> requests.Response:
         response = self._request(
             method="post",
-            url=OnyxClientBase.ENDPOINTS["logout"](self.config.domain),
+            url=OnyxEndpoint["logout"](self.config.domain),
         )
         if response.ok:
             self.config.token = None
@@ -1022,7 +620,7 @@ class OnyxClientBase:
     def logoutall(self) -> requests.Response:
         response = self._request(
             method="post",
-            url=OnyxClientBase.ENDPOINTS["logoutall"](self.config.domain),
+            url=OnyxEndpoint["logoutall"](self.config.domain),
         )
         if response.ok:
             self.config.token = None
@@ -1032,42 +630,42 @@ class OnyxClientBase:
     def profile(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["profile"](self.config.domain),
+            url=OnyxEndpoint["profile"](self.config.domain),
         )
         return response
 
     def activity(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["activity"](self.config.domain),
+            url=OnyxEndpoint["activity"](self.config.domain),
         )
         return response
 
     def approve(self, username: str) -> requests.Response:
         response = self._request(
             method="patch",
-            url=OnyxClientBase.ENDPOINTS["approve"](self.config.domain, username),
+            url=OnyxEndpoint["approve"](self.config.domain, username),
         )
         return response
 
     def waiting(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["waiting"](self.config.domain),
+            url=OnyxEndpoint["waiting"](self.config.domain),
         )
         return response
 
     def site_users(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["siteusers"](self.config.domain),
+            url=OnyxEndpoint["siteusers"](self.config.domain),
         )
         return response
 
     def all_users(self) -> requests.Response:
         response = self._request(
             method="get",
-            url=OnyxClientBase.ENDPOINTS["allusers"](self.config.domain),
+            url=OnyxEndpoint["allusers"](self.config.domain),
         )
         return response
 

--- a/onyx/core.py
+++ b/onyx/core.py
@@ -1,0 +1,1126 @@
+import posixpath
+import csv
+import inspect
+import requests
+from requests import HTTPError, RequestException
+from typing import Any, Generator, List, Dict, TextIO, Optional, Union
+from .config import OnyxConfig
+from .field import OnyxField
+from .exceptions import (
+    OnyxClientError,
+    OnyxConnectionError,
+    OnyxRequestError,
+    OnyxServerError,
+)
+
+
+class OnyxClientBase:
+    __slots__ = "config", "_request_handler", "_session"
+    ENDPOINTS = {
+        "projects": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects/",
+            ),
+            domain=domain,
+        ),
+        "types": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects/types/",
+            ),
+            domain=domain,
+        ),
+        "lookups": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects/lookups/",
+            ),
+            domain=domain,
+        ),
+        "fields": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "fields/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "choices": lambda domain, project, field: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "choices",
+                str(field),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            field=field,
+        ),
+        "get": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                str(climb_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            climb_id=climb_id,
+        ),
+        "filter": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "query": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "query/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "history": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "history",
+                str(climb_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            climb_id=climb_id,
+        ),
+        "identify": lambda domain, project, field: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "identify",
+                str(field),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            field=field,
+        ),
+        "create": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "create.test": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "test/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "update": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                str(climb_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            climb_id=climb_id,
+        ),
+        "update.test": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "test",
+                str(climb_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            climb_id=climb_id,
+        ),
+        "delete": lambda domain, project, climb_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                str(climb_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            climb_id=climb_id,
+        ),
+        "analysis.fields": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/fields/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "analysis.choices": lambda domain, project, field: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/choices",
+                str(field),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            field=field,
+        ),
+        "analysis.get": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis",
+                str(analysis_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            analysis_id=analysis_id,
+        ),
+        "analysis.filter": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "analysis.history": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/history",
+                str(analysis_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            analysis_id=analysis_id,
+        ),
+        "analysis.create": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "analysis.create.test": lambda domain, project: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/test/",
+            ),
+            domain=domain,
+            project=project,
+        ),
+        "analysis.update": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis",
+                str(analysis_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            analysis_id=analysis_id,
+        ),
+        "analysis.update.test": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis/test",
+                str(analysis_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            analysis_id=analysis_id,
+        ),
+        "analysis.delete": lambda domain, project, analysis_id: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "projects",
+                str(project),
+                "analysis",
+                str(analysis_id),
+                "",
+            ),
+            domain=domain,
+            project=project,
+            analysis_id=analysis_id,
+        ),
+        "register": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/register/",
+            ),
+            domain=domain,
+        ),
+        "login": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/login/",
+            ),
+            domain=domain,
+        ),
+        "logout": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/logout/",
+            ),
+            domain=domain,
+        ),
+        "logoutall": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/logoutall/",
+            ),
+            domain=domain,
+        ),
+        "profile": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/profile/",
+            ),
+            domain=domain,
+        ),
+        "activity": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/activity/",
+            ),
+            domain=domain,
+        ),
+        "waiting": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/waiting/",
+            ),
+            domain=domain,
+        ),
+        "approve": lambda domain, username: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/approve",
+                str(username),
+                "",
+            ),
+            domain=domain,
+            username=username,
+        ),
+        "siteusers": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/site/",
+            ),
+            domain=domain,
+        ),
+        "allusers": lambda domain: OnyxClientBase._handle_endpoint(
+            lambda: posixpath.join(
+                str(domain),
+                "accounts/all/",
+            ),
+            domain=domain,
+        ),
+    }
+
+    def __init__(self, config: OnyxConfig):
+        self.config = config
+        self._session = None
+        self._request_handler = requests.request
+
+    def __enter__(self):
+        self._session = requests.Session()
+        self._request_handler = self._session.request
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self._session:
+            self._session.close()
+        self._request_handler = requests.request
+
+    @classmethod
+    def _handle_endpoint(cls, endpoint, **kwargs):
+        for name, val in kwargs.items():
+            if val is None or not str(val).strip():
+                raise OnyxClientError(f"Argument '{name}' was not provided.")
+
+            val = str(val).strip()
+
+            if name != "domain":
+                for char in "/?":
+                    if char in val:
+                        raise OnyxClientError(
+                            f"Argument '{name}' contains invalid character: '{char}'."
+                        )
+
+                # Crude but effective prevention of unexpectedly calling other endpoints
+                # Its not the end of the world if that did happen, but to the user it would be quite confusing
+                clashes = {
+                    "project": ["types", "lookups"],
+                    "climb_id": [
+                        "test",
+                        "query",
+                        "fields",
+                        "choices",
+                        "history",
+                        "identify",
+                    ],
+                }
+
+                if name in clashes:
+                    for clash in clashes[name]:
+                        if val == clash:
+                            raise OnyxClientError(
+                                f"Argument '{name}' cannot have value '{val}'. This creates a URL that resolves to a different endpoint."
+                            )
+
+        return endpoint()
+
+    def _request(self, method: str, retries: int = 3, **kwargs) -> requests.Response:
+        if not retries:
+            raise Exception(
+                "Request retry limit reached. This should not be possible..."
+            )
+
+        kwargs.setdefault("headers", {}).update(
+            {"Authorization": f"Token {self.config.token}"}
+        )
+        method_response = self._request_handler(method, **kwargs)
+
+        # Token has expired or was invalid.
+        # If username and password were provided, log in again, obtain a new token, and re-run the method.
+        if (
+            method_response.status_code == 401
+            and self.config.username
+            and self.config.password
+        ):
+            OnyxClientBase.login(self).raise_for_status()
+            # A retry mechanism has been incorporated as a failsafe.
+            # This is to protect against the case where an onyx endpoint returns a 401 status code,
+            # despite the user being able to successfully log in, leading to an infinite loop of
+            # re-logging in and re-hitting the endpoint.
+            # This scenario should not be possible. But if it happened, it would not be fun at all.
+            # So, better safe than sorry...
+            return self._request(method, retries=retries - 1, **kwargs)
+
+        return method_response
+
+    def _csv_upload(
+        self,
+        method: str,
+        endpoint: str,
+        project: str,
+        csv_file: TextIO,
+        fields: Optional[Dict[str, Any]] = None,
+        delimiter: Optional[str] = None,
+        multiline: bool = False,
+        test: bool = False,
+        climb_id_required: bool = False,
+    ) -> Generator[requests.Response, Any, None]:
+        # Get appropriate endpoint for test/prod
+        if test:
+            endpoint += ".test"
+
+        # Create CSV reader
+        if delimiter is None:
+            reader = csv.DictReader(
+                csv_file,
+                skipinitialspace=True,
+            )
+        else:
+            reader = csv.DictReader(
+                csv_file,
+                delimiter=delimiter,
+                skipinitialspace=True,
+            )
+
+        # Read the first two records (if they exist) and store in 'records' list
+        # This is done to protect against two scenarios:
+        # - There are no records in the file (never allowed)
+        # - There is more than one record, but multiline = False (not allowed)
+        records = []
+
+        record_1 = next(reader, None)
+        if record_1:
+            records.append(record_1)
+        else:
+            raise OnyxClientError("File must contain at least one record.")
+
+        record_2 = next(reader, None)
+        if record_2:
+            if not multiline:
+                raise OnyxClientError(
+                    "File contains multiple records but this is not allowed. To upload multiple records, set 'multiline' = True."
+                )
+            records.append(record_2)
+
+        # Iterate over the read and unread records and upload sequentially
+        for iterator in (records, reader):
+            for record in iterator:
+                if fields:
+                    record = record | fields
+
+                if climb_id_required:
+                    # Grab the climb_id, if required for the URL
+                    climb_id = record.pop("climb_id", None)
+                    if not climb_id:
+                        raise OnyxClientError(
+                            "Record requires a 'climb_id' for upload."
+                        )
+                    url = OnyxClientBase.ENDPOINTS[endpoint](
+                        self.config.domain, project, climb_id
+                    )
+                else:
+                    url = OnyxClientBase.ENDPOINTS[endpoint](
+                        self.config.domain, project
+                    )
+
+                response = self._request(
+                    method=method,
+                    url=url,
+                    json=record,
+                )
+                yield response
+
+    def _csv_handle_multiline(
+        self,
+        responses: Generator[requests.Response, Any, None],
+        multiline: bool,
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        if multiline:
+            results = []
+            for response in responses:
+                response.raise_for_status()
+                results.append(response.json()["data"])
+            return results
+        else:
+            response = next(responses, None)
+            if response is None:
+                raise OnyxClientError("Iterator must contain at least one record.")
+
+            response.raise_for_status()
+            return response.json()["data"]
+
+    def projects(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["projects"](self.config.domain),
+        )
+        return response
+
+    def types(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["types"](self.config.domain),
+        )
+        return response
+
+    def lookups(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["lookups"](self.config.domain),
+        )
+        return response
+
+    def fields(self, project: str, endpoint: str = "fields") -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project),
+        )
+        return response
+
+    def choices(
+        self, project: str, field: str, endpoint: str = "choices"
+    ) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project, field),
+        )
+        return response
+
+    def get(
+        self,
+        project: str,
+        climb_id: str,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+        endpoint: str = "get",
+    ) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS[endpoint](
+                self.config.domain, project, climb_id
+            ),
+            params={"include": include, "exclude": exclude},
+        )
+        return response
+
+    def filter(
+        self,
+        project: str,
+        fields: Optional[Dict[str, Any]] = None,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+        summarise: Union[List[str], str, None] = None,
+        endpoint: str = "filter",
+        **kwargs: Any,
+    ) -> Generator[requests.Response, Any, None]:
+        if fields is None:
+            fields = {}
+
+        for field, value in kwargs.items():
+            if type(value) in {list, tuple, set}:
+                value = ",".join(map(lambda x: str(x) if x is not None else "", value))
+            fields[field] = value
+
+        for field, value in fields.items():
+            if type(value) in {list, tuple, set}:
+                fields[field] = [v if v is not None else "" for v in value]
+            if value is None:
+                fields[field] = ""
+
+        fields = fields | {
+            "include": include,
+            "exclude": exclude,
+            "summarise": summarise,
+        }
+
+        _next = OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project)
+
+        while _next is not None:
+            response = self._request(
+                method="get",
+                url=_next,
+                params=fields,
+            )
+            yield response
+
+            fields = None
+            if response.ok:
+                _next = response.json().get("next")
+            else:
+                _next = None
+
+    def query(
+        self,
+        project: str,
+        query: Optional[OnyxField] = None,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+        summarise: Union[List[str], str, None] = None,
+        endpoint: str = "query",
+    ) -> Generator[requests.Response, Any, None]:
+        if query:
+            if not isinstance(query, OnyxField):
+                raise OnyxClientError(
+                    f"Query must be an instance of {OnyxField}. Received: {type(query)}"
+                )
+            else:
+                query_json = query.query
+        else:
+            query_json = None
+
+        fields = {
+            "include": include,
+            "exclude": exclude,
+            "summarise": summarise,
+        }
+        _next = OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project)
+
+        while _next is not None:
+            response = self._request(
+                method="post",
+                url=_next,
+                json=query_json,
+                params=fields,
+            )
+            yield response
+
+            fields = None
+            if response.ok:
+                _next = response.json().get("next")
+            else:
+                _next = None
+
+    @classmethod
+    def to_csv(
+        cls,
+        csv_file: TextIO,
+        data: Union[List[Dict[str, Any]], Generator[Dict[str, Any], Any, None]],
+        delimiter: Optional[str] = None,
+    ):
+        # Ensure data is an iterator
+        if inspect.isgenerator(data):
+            data_iterator = data
+        else:
+            data_iterator = iter(data)
+
+        row = next(data_iterator, None)
+        if row:
+            fields = row.keys()
+
+            # Create CSV writer
+            if delimiter is None:
+                writer = csv.DictWriter(
+                    csv_file,
+                    fieldnames=fields,
+                )
+            else:
+                writer = csv.DictWriter(
+                    csv_file,
+                    fieldnames=fields,
+                    delimiter=delimiter,
+                )
+
+            # Write data
+            writer.writeheader()
+            writer.writerow(row)
+            for row in data_iterator:
+                writer.writerow(row)
+
+    def history(
+        self,
+        project: str,
+        climb_id: str,
+        endpoint: str = "history",
+    ) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS[endpoint](
+                self.config.domain, project, climb_id
+            ),
+        )
+        return response
+
+    def identify(
+        self,
+        project: str,
+        field: str,
+        value: str,
+        site: Optional[str] = None,
+        endpoint="identify",
+    ) -> requests.Response:
+        identify_json = {"value": value}
+        if site:
+            identify_json = identify_json | {"site": site}
+
+        response = self._request(
+            method="post",
+            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project, field),
+            json=identify_json,
+        )
+        return response
+
+    def create(
+        self,
+        project: str,
+        fields: Dict[str, Any],
+        test: bool = False,
+        endpoint: str = "create",
+    ) -> requests.Response:
+        if test:
+            endpoint += ".test"
+
+        response = self._request(
+            method="post",
+            url=OnyxClientBase.ENDPOINTS[endpoint](self.config.domain, project),
+            json=fields,
+        )
+        return response
+
+    def update(
+        self,
+        project: str,
+        climb_id: str,
+        fields: Optional[Dict[str, Any]] = None,
+        test: bool = False,
+        endpoint: str = "update",
+    ) -> requests.Response:
+        if test:
+            endpoint += ".test"
+
+        response = self._request(
+            method="patch",
+            url=OnyxClientBase.ENDPOINTS[endpoint](
+                self.config.domain, project, climb_id
+            ),
+            json=fields,
+        )
+        return response
+
+    def delete(
+        self,
+        project: str,
+        climb_id: str,
+        endpoint: str = "delete",
+    ) -> requests.Response:
+        response = self._request(
+            method="delete",
+            url=OnyxClientBase.ENDPOINTS[endpoint](
+                self.config.domain, project, climb_id
+            ),
+        )
+        return response
+
+    def csv_create(
+        self,
+        project: str,
+        csv_file: TextIO,
+        fields: Optional[Dict[str, Any]] = None,
+        delimiter: Optional[str] = None,
+        multiline: bool = False,
+        test: bool = False,
+    ) -> Generator[requests.Response, Any, None]:
+        yield from self._csv_upload(
+            method="post",
+            endpoint="create",
+            project=project,
+            csv_file=csv_file,
+            fields=fields,
+            delimiter=delimiter,
+            multiline=multiline,
+            test=test,
+        )
+
+    def csv_update(
+        self,
+        project: str,
+        csv_file: TextIO,
+        fields: Optional[Dict[str, Any]] = None,
+        delimiter: Optional[str] = None,
+        multiline: bool = False,
+        test: bool = False,
+    ) -> Generator[requests.Response, Any, None]:
+        yield from self._csv_upload(
+            method="patch",
+            endpoint="update",
+            project=project,
+            csv_file=csv_file,
+            fields=fields,
+            delimiter=delimiter,
+            multiline=multiline,
+            test=test,
+            climb_id_required=True,
+        )
+
+    def csv_delete(
+        self,
+        project: str,
+        csv_file: TextIO,
+        delimiter: Optional[str] = None,
+        multiline: bool = False,
+    ) -> Generator[requests.Response, Any, None]:
+        yield from self._csv_upload(
+            method="delete",
+            endpoint="delete",
+            project=project,
+            csv_file=csv_file,
+            delimiter=delimiter,
+            multiline=multiline,
+            climb_id_required=True,
+        )
+
+    def analysis_fields(self, project: str) -> requests.Response:
+        return OnyxClientBase.fields(
+            self,
+            project=project,
+            endpoint="analysis.fields",
+        )
+
+    def analysis_choices(self, project: str, field: str) -> requests.Response:
+        return OnyxClientBase.choices(
+            self,
+            project=project,
+            field=field,
+            endpoint="analysis.choices",
+        )
+
+    def get_analysis(
+        self,
+        project: str,
+        analysis_id: str,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+    ) -> requests.Response:
+        return OnyxClientBase.get(
+            self,
+            project=project,
+            climb_id=analysis_id,
+            include=include,
+            exclude=exclude,
+            endpoint="analysis.get",
+        )
+
+    def filter_analyses(
+        self,
+        project: str,
+        fields: Optional[Dict[str, Any]] = None,
+        include: Union[List[str], str, None] = None,
+        exclude: Union[List[str], str, None] = None,
+        summarise: Union[List[str], str, None] = None,
+        **kwargs: Any,
+    ) -> Generator[requests.Response, Any, None]:
+        return OnyxClientBase.filter(
+            self,
+            project=project,
+            fields=fields,
+            include=include,
+            exclude=exclude,
+            summarise=summarise,
+            endpoint="analysis.filter",
+            **kwargs,
+        )
+
+    def analysis_history(
+        self,
+        project: str,
+        analysis_id: str,
+    ) -> requests.Response:
+        return OnyxClientBase.history(
+            self,
+            project=project,
+            climb_id=analysis_id,
+            endpoint="analysis.history",
+        )
+
+    def create_analysis(
+        self,
+        project: str,
+        fields: Dict[str, Any],
+        test: bool = False,
+    ) -> requests.Response:
+        return OnyxClientBase.create(
+            self,
+            project=project,
+            fields=fields,
+            test=test,
+            endpoint="analysis.create",
+        )
+
+    def update_analysis(
+        self,
+        project: str,
+        analysis_id: str,
+        fields: Optional[Dict[str, Any]] = None,
+        test: bool = False,
+    ) -> requests.Response:
+        return OnyxClientBase.update(
+            self,
+            project=project,
+            climb_id=analysis_id,
+            fields=fields,
+            test=test,
+            endpoint="analysis.update",
+        )
+
+    def delete_analysis(
+        self,
+        project: str,
+        analysis_id: str,
+    ) -> requests.Response:
+        return OnyxClientBase.delete(
+            self,
+            project=project,
+            climb_id=analysis_id,
+            endpoint="analysis.delete",
+        )
+
+    @classmethod
+    def register(
+        cls,
+        domain: str,
+        first_name: str,
+        last_name: str,
+        email: str,
+        site: str,
+        password: str,
+    ) -> requests.Response:
+        response = requests.post(
+            OnyxClientBase.ENDPOINTS["register"](domain),
+            json={
+                "first_name": first_name,
+                "last_name": last_name,
+                "password": password,
+                "email": email,
+                "site": site,
+            },
+        )
+        return response
+
+    def login(self) -> requests.Response:
+        if self.config.username and self.config.password:
+            credentials = (self.config.username, self.config.password)
+        else:
+            credentials = None
+
+        response = self._request_handler(
+            "post",
+            auth=credentials,
+            url=OnyxClientBase.ENDPOINTS["login"](self.config.domain),
+        )
+        if response.ok:
+            self.config.token = response.json()["data"]["token"]
+
+        return response
+
+    def logout(self) -> requests.Response:
+        response = self._request(
+            method="post",
+            url=OnyxClientBase.ENDPOINTS["logout"](self.config.domain),
+        )
+        if response.ok:
+            self.config.token = None
+
+        return response
+
+    def logoutall(self) -> requests.Response:
+        response = self._request(
+            method="post",
+            url=OnyxClientBase.ENDPOINTS["logoutall"](self.config.domain),
+        )
+        if response.ok:
+            self.config.token = None
+
+        return response
+
+    def profile(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["profile"](self.config.domain),
+        )
+        return response
+
+    def activity(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["activity"](self.config.domain),
+        )
+        return response
+
+    def approve(self, username: str) -> requests.Response:
+        response = self._request(
+            method="patch",
+            url=OnyxClientBase.ENDPOINTS["approve"](self.config.domain, username),
+        )
+        return response
+
+    def waiting(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["waiting"](self.config.domain),
+        )
+        return response
+
+    def site_users(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["siteusers"](self.config.domain),
+        )
+        return response
+
+    def all_users(self) -> requests.Response:
+        response = self._request(
+            method="get",
+            url=OnyxClientBase.ENDPOINTS["allusers"](self.config.domain),
+        )
+        return response
+
+
+def onyx_errors(method):
+    """
+    Decorator that coerces `requests` library errors into appropriate `OnyxError` subclasses.
+    """
+    if inspect.isgeneratorfunction(method):
+
+        def wrapped_generator_method(self, *args, **kwargs):
+            try:
+                yield from method(self, *args, **kwargs)
+
+            except HTTPError as e:
+                if e.response is None:
+                    # TODO: Seems this does not need handling?
+                    raise e  #  type: ignore
+                elif e.response.status_code < 500:
+                    raise OnyxRequestError(
+                        message=str(e),
+                        response=e.response,
+                    ) from e
+                else:
+                    raise OnyxServerError(
+                        message=str(e),
+                        response=e.response,
+                    ) from e
+            except RequestException as e:
+                raise OnyxConnectionError(str(e)) from e
+
+        return wrapped_generator_method
+    else:
+
+        def wrapped_method(self, *args, **kwargs):
+            try:
+                return method(self, *args, **kwargs)
+
+            except HTTPError as e:
+                if e.response is None:
+                    # TODO: Seems this does not need handling?
+                    raise e  #  type: ignore
+                elif e.response.status_code < 500:
+                    raise OnyxRequestError(
+                        message=str(e),
+                        response=e.response,
+                    ) from e
+                else:
+                    raise OnyxServerError(
+                        message=str(e),
+                        response=e.response,
+                    ) from e
+            except RequestException as e:
+                raise OnyxConnectionError(str(e)) from e
+
+        return wrapped_method

--- a/onyx/core.py
+++ b/onyx/core.py
@@ -495,7 +495,7 @@ class OnyxClientBase:
             endpoint="analysis.get",
         )
 
-    def filter_analyses(
+    def filter_analysis(
         self,
         project: str,
         fields: Optional[Dict[str, Any]] = None,

--- a/onyx/endpoints.py
+++ b/onyx/endpoints.py
@@ -30,7 +30,6 @@ def handle_endpoint(endpoint, **kwargs):
                 ],
                 "analysis_id": [
                     "test",
-                    "filter",
                     "fields",
                     "choices",
                     "history",

--- a/onyx/endpoints.py
+++ b/onyx/endpoints.py
@@ -1,0 +1,402 @@
+import posixpath
+from .exceptions import OnyxClientError
+
+
+def handle_endpoint(endpoint, **kwargs):
+    for name, val in kwargs.items():
+        if val is None or not str(val).strip():
+            raise OnyxClientError(f"Argument '{name}' was not provided.")
+
+        val = str(val).strip()
+
+        if name != "domain":
+            for char in "/?":
+                if char in val:
+                    raise OnyxClientError(
+                        f"Argument '{name}' contains invalid character: '{char}'."
+                    )
+
+            # Crude but effective prevention of unexpectedly calling other endpoints
+            # Its not the end of the world if that did happen, but to the user it would be quite confusing
+            clashes = {
+                "project": ["types", "lookups"],
+                "climb_id": [
+                    "test",
+                    "query",
+                    "fields",
+                    "choices",
+                    "history",
+                    "identify",
+                ],
+                "analysis_id": [
+                    "test",
+                    "filter",
+                    "fields",
+                    "choices",
+                    "history",
+                ],
+            }
+
+            if name in clashes:
+                for clash in clashes[name]:
+                    if val == clash:
+                        raise OnyxClientError(
+                            f"Argument '{name}' cannot have value '{val}'. This creates a URL that resolves to a different endpoint."
+                        )
+
+    return endpoint()
+
+
+# TODO: Convert to an enum for argument checking
+OnyxEndpoint = {
+    "projects": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects/",
+        ),
+        domain=domain,
+    ),
+    "types": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects/types/",
+        ),
+        domain=domain,
+    ),
+    "lookups": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects/lookups/",
+        ),
+        domain=domain,
+    ),
+    "fields": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "fields/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "choices": lambda domain, project, field: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "choices",
+            str(field),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        field=field,
+    ),
+    "get": lambda domain, project, climb_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            str(climb_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        climb_id=climb_id,
+    ),
+    "filter": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "query": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "query/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "history": lambda domain, project, climb_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "history",
+            str(climb_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        climb_id=climb_id,
+    ),
+    "identify": lambda domain, project, field: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "identify",
+            str(field),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        field=field,
+    ),
+    "create": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "create.test": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "test/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "update": lambda domain, project, climb_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            str(climb_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        climb_id=climb_id,
+    ),
+    "update.test": lambda domain, project, climb_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "test",
+            str(climb_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        climb_id=climb_id,
+    ),
+    "delete": lambda domain, project, climb_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            str(climb_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        climb_id=climb_id,
+    ),
+    "analysis.fields": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/fields/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "analysis.choices": lambda domain, project, field: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/choices",
+            str(field),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        field=field,
+    ),
+    "analysis.get": lambda domain, project, analysis_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis",
+            str(analysis_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        analysis_id=analysis_id,
+    ),
+    "analysis.filter": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "analysis.history": lambda domain, project, analysis_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/history",
+            str(analysis_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        analysis_id=analysis_id,
+    ),
+    "analysis.create": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "analysis.create.test": lambda domain, project: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/test/",
+        ),
+        domain=domain,
+        project=project,
+    ),
+    "analysis.update": lambda domain, project, analysis_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis",
+            str(analysis_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        analysis_id=analysis_id,
+    ),
+    "analysis.update.test": lambda domain, project, analysis_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis/test",
+            str(analysis_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        analysis_id=analysis_id,
+    ),
+    "analysis.delete": lambda domain, project, analysis_id: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "projects",
+            str(project),
+            "analysis",
+            str(analysis_id),
+            "",
+        ),
+        domain=domain,
+        project=project,
+        analysis_id=analysis_id,
+    ),
+    "register": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/register/",
+        ),
+        domain=domain,
+    ),
+    "login": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/login/",
+        ),
+        domain=domain,
+    ),
+    "logout": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/logout/",
+        ),
+        domain=domain,
+    ),
+    "logoutall": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/logoutall/",
+        ),
+        domain=domain,
+    ),
+    "profile": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/profile/",
+        ),
+        domain=domain,
+    ),
+    "activity": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/activity/",
+        ),
+        domain=domain,
+    ),
+    "waiting": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/waiting/",
+        ),
+        domain=domain,
+    ),
+    "approve": lambda domain, username: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/approve",
+            str(username),
+            "",
+        ),
+        domain=domain,
+        username=username,
+    ),
+    "siteusers": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/site/",
+        ),
+        domain=domain,
+    ),
+    "allusers": lambda domain: handle_endpoint(
+        lambda: posixpath.join(
+            str(domain),
+            "accounts/all/",
+        ),
+        domain=domain,
+    ),
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import io
 import requests
 import pytest
 from unittest import TestCase, mock
-from onyx import OnyxConfig, OnyxClient, exceptions, OnyxField
+from onyx import OnyxConfig, OnyxClient, exceptions, OnyxField, OnyxEndpoint
 
 
 DOMAIN = "https://onyx.domain"
@@ -168,8 +168,8 @@ GET_DATA = {
         "run_name": "run-456",
     },
 }
-FILTER_PAGE_1_URL = f"{OnyxClient.ENDPOINTS['filter'](DOMAIN, PROJECT)}?cursor=page_1"
-FILTER_PAGE_2_URL = f"{OnyxClient.ENDPOINTS['filter'](DOMAIN, PROJECT)}?cursor=page_2"
+FILTER_PAGE_1_URL = f"{OnyxEndpoint['filter'](DOMAIN, PROJECT)}?cursor=page_1"
+FILTER_PAGE_2_URL = f"{OnyxEndpoint['filter'](DOMAIN, PROJECT)}?cursor=page_2"
 FILTER_PAGE_1_DATA = {
     "status": "success",
     "code": 200,
@@ -308,8 +308,8 @@ FILTER_ERROR_CAUSING_PROJECT_DATA = {
         "detail": "Internal server error. Deary me...",
     },
 }
-QUERY_PAGE_1_URL = f"{OnyxClient.ENDPOINTS['query'](DOMAIN, PROJECT)}?cursor=page_1"
-QUERY_PAGE_2_URL = f"{OnyxClient.ENDPOINTS['query'](DOMAIN, PROJECT)}?cursor=page_2"
+QUERY_PAGE_1_URL = f"{OnyxEndpoint['query'](DOMAIN, PROJECT)}?cursor=page_1"
+QUERY_PAGE_2_URL = f"{OnyxEndpoint['query'](DOMAIN, PROJECT)}?cursor=page_2"
 QUERY_PAGE_1_DATA = {
     "status": "success",
     "code": 200,
@@ -661,7 +661,7 @@ def mock_request(
     if url.startswith(BAD_DOMAIN):
         raise requests.ConnectionError
 
-    if method == "post" and url == OnyxClient.ENDPOINTS["login"](DOMAIN):
+    if method == "post" and url == OnyxEndpoint["login"](DOMAIN):
         if auth == (USERNAME, PASSWORD):
             return MockResponse(LOGIN_DATA)
         else:
@@ -671,19 +671,16 @@ def mock_request(
         return MockResponse(INVALID_AUTH_DATA)
 
     if method == "post":
-        if (
-            url == OnyxClient.ENDPOINTS["create"](DOMAIN, PROJECT)
-            and json == CREATE_FIELDS
-        ):
+        if url == OnyxEndpoint["create"](DOMAIN, PROJECT) and json == CREATE_FIELDS:
             return MockResponse(CREATE_DATA)
 
         elif (
-            url == OnyxClient.ENDPOINTS["create.test"](DOMAIN, PROJECT)
+            url == OnyxEndpoint["create.test"](DOMAIN, PROJECT)
             and json == CREATE_FIELDS
         ):
             return MockResponse(TESTCREATE_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["query"](DOMAIN, PROJECT):
+        elif url == OnyxEndpoint["query"](DOMAIN, PROJECT):
             if json == QUERY_SPECIFIC_BODY:
                 if params.get("include") == INCLUDE_FIELDS:
                     return MockResponse(FILTER_SPECIFIC_INCLUDE_DATA)
@@ -697,13 +694,13 @@ def mock_request(
         elif url == QUERY_PAGE_2_URL:
             return MockResponse(QUERY_PAGE_2_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["logout"](DOMAIN):
+        elif url == OnyxEndpoint["logout"](DOMAIN):
             return MockResponse(LOGOUT_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["logoutall"](DOMAIN):
+        elif url == OnyxEndpoint["logoutall"](DOMAIN):
             return MockResponse(LOGOUTALL_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["identify"](DOMAIN, PROJECT, IDENTIFY_FIELD):
+        elif url == OnyxEndpoint["identify"](DOMAIN, PROJECT, IDENTIFY_FIELD):
             if json == IDENTIFY_FIELDS:
                 return MockResponse(IDENTIFY_DATA)
 
@@ -711,31 +708,31 @@ def mock_request(
                 return MockResponse(IDENTIFY_OTHER_SITE_DATA)
 
     elif method == "get":
-        if url == OnyxClient.ENDPOINTS["projects"](DOMAIN):
+        if url == OnyxEndpoint["projects"](DOMAIN):
             return MockResponse(PROJECT_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["types"](DOMAIN):
+        elif url == OnyxEndpoint["types"](DOMAIN):
             return MockResponse(TYPES_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["lookups"](DOMAIN):
+        elif url == OnyxEndpoint["lookups"](DOMAIN):
             return MockResponse(LOOKUPS_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["fields"](DOMAIN, PROJECT):
+        elif url == OnyxEndpoint["fields"](DOMAIN, PROJECT):
             return MockResponse(FIELDS_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["fields"](DOMAIN, NOT_PROJECT):
+        elif url == OnyxEndpoint["fields"](DOMAIN, NOT_PROJECT):
             return MockResponse(FIELDS_NOT_PROJECT_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["fields"](DOMAIN, ERROR_CAUSING_PROJECT):
+        elif url == OnyxEndpoint["fields"](DOMAIN, ERROR_CAUSING_PROJECT):
             return MockResponse(FIELDS_ERROR_CAUSING_PROJECT_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["choices"](DOMAIN, PROJECT, CHOICE_FIELD):
+        elif url == OnyxEndpoint["choices"](DOMAIN, PROJECT, CHOICE_FIELD):
             return MockResponse(CHOICES_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["get"](DOMAIN, PROJECT, CLIMB_ID):
+        elif url == OnyxEndpoint["get"](DOMAIN, PROJECT, CLIMB_ID):
             return MockResponse(GET_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["filter"](DOMAIN, PROJECT):
+        elif url == OnyxEndpoint["filter"](DOMAIN, PROJECT):
             if params.get(UNKNOWN_FIELD):
                 return MockResponse(FILTER_UNKNOWN_FIELD_DATA)
             elif params.get(NONE_FIELD) == "":
@@ -757,48 +754,48 @@ def mock_request(
             else:
                 return MockResponse(FILTER_PAGE_1_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["filter"](DOMAIN, ERROR_CAUSING_PROJECT):
+        elif url == OnyxEndpoint["filter"](DOMAIN, ERROR_CAUSING_PROJECT):
             return MockResponse(FILTER_ERROR_CAUSING_PROJECT_DATA)
 
         elif url == FILTER_PAGE_2_URL:
             return MockResponse(FILTER_PAGE_2_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["history"](DOMAIN, PROJECT, CLIMB_ID):
+        elif url == OnyxEndpoint["history"](DOMAIN, PROJECT, CLIMB_ID):
             return MockResponse(HISTORY_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["profile"](DOMAIN):
+        elif url == OnyxEndpoint["profile"](DOMAIN):
             return MockResponse(PROFILE_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["activity"](DOMAIN):
+        elif url == OnyxEndpoint["activity"](DOMAIN):
             return MockResponse(ACTIVITY_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["waiting"](DOMAIN):
+        elif url == OnyxEndpoint["waiting"](DOMAIN):
             return MockResponse(WAITING_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["siteusers"](DOMAIN):
+        elif url == OnyxEndpoint["siteusers"](DOMAIN):
             return MockResponse(SITE_USERS_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["allusers"](DOMAIN):
+        elif url == OnyxEndpoint["allusers"](DOMAIN):
             return MockResponse(ALL_USERS_DATA)
 
     elif method == "patch":
         if (
-            url == OnyxClient.ENDPOINTS["update"](DOMAIN, PROJECT, CLIMB_ID)
+            url == OnyxEndpoint["update"](DOMAIN, PROJECT, CLIMB_ID)
             and json == UPDATE_FIELDS
         ):
             return MockResponse(UPDATE_DATA)
 
         elif (
-            url == OnyxClient.ENDPOINTS["update.test"](DOMAIN, PROJECT, CLIMB_ID)
+            url == OnyxEndpoint["update.test"](DOMAIN, PROJECT, CLIMB_ID)
             and json == UPDATE_FIELDS
         ):
             return MockResponse(TESTUPDATE_DATA)
 
-        elif url == OnyxClient.ENDPOINTS["approve"](DOMAIN, OTHER_USERNAME):
+        elif url == OnyxEndpoint["approve"](DOMAIN, OTHER_USERNAME):
             return MockResponse(APPROVE_DATA)
 
     elif method == "delete":
-        if url == OnyxClient.ENDPOINTS["delete"](DOMAIN, PROJECT, CLIMB_ID):
+        if url == OnyxEndpoint["delete"](DOMAIN, PROJECT, CLIMB_ID):
             return MockResponse(DELETE_DATA)
 
     return MockResponse(
@@ -814,7 +811,7 @@ def mock_register_post(url=None, json=None):
     if not json:
         json = {}
 
-    if url == OnyxClient.ENDPOINTS["register"](DOMAIN) and all(
+    if url == OnyxEndpoint["register"](DOMAIN) and all(
         json.get(field) == value for field, value in REGISTER_FIELDS.items()
     ):
         return MockResponse(REGISTER_DATA)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,6 +93,9 @@ FIELDS_DATA = {
     "status": "success",
     "code": 200,
     "data": {
+        "name": "Project Name",
+        "description": "Project Description",
+        "object_type": "records",
         "version": "0.1.0",
         "fields": {
             "climb_id": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -678,7 +678,7 @@ def mock_request(
             return MockResponse(CREATE_DATA)
 
         elif (
-            url == OnyxClient.ENDPOINTS["testcreate"](DOMAIN, PROJECT)
+            url == OnyxClient.ENDPOINTS["create.test"](DOMAIN, PROJECT)
             and json == CREATE_FIELDS
         ):
             return MockResponse(TESTCREATE_DATA)
@@ -789,7 +789,7 @@ def mock_request(
             return MockResponse(UPDATE_DATA)
 
         elif (
-            url == OnyxClient.ENDPOINTS["testupdate"](DOMAIN, PROJECT, CLIMB_ID)
+            url == OnyxClient.ENDPOINTS["update.test"](DOMAIN, PROJECT, CLIMB_ID)
             and json == UPDATE_FIELDS
         ):
             return MockResponse(TESTUPDATE_DATA)


### PR DESCRIPTION
# Changes
## Documentation Website
* Removed sticky tabs, added navigation sections.
* Hide base classes in Python API docs.

## API
* Added `OnyxClient` methods `analysis_fields`, `analysis_choices`, `get_analysis`, `filter_analysis`, `analysis_history`, `create_analysis`, `update_analysis` and `delete_analysis`.
* Abstracted shared logic for record/analysis endpoints into `OnyxClientBase` and moved this into `core.py` file.

## Command-line Interface
* Moved commands into relevant panels - `DATA`, `RECORDS`, `ANALYSES` and `ACCOUNTS`.
* Moved core CLI function logic into base functions, and then created specific functions for each of record/analysis actions. E.g. moved shared `fields` logic into `fields_base` function, kept `fields` function for record fields, and added `analysis_fields` function for analysis fields.
* Add documentation link in main help page.

## Endpoint Logic Restructuring
* Moved endpoint definitions/handling into `endpoints.py`.

## Tests
* Added tests `test_analysis_fields`, `test_analysis_choices`, `test_get_analysis`, `test_filter_analysis`, `test_analysis_history`, `test_create_analysis`, `test_update_analysis` and `test_delete_analysis`.
