### PR TITLE
Use functools.wraps to pass docstrings of wrapped functions

### DIFF
--- a/onyx/core.py
+++ b/onyx/core.py
@@ -1,4 +1,5 @@
 import csv
+import functools
 import inspect
 import requests
 from requests import HTTPError, RequestException
@@ -699,7 +700,7 @@ def onyx_errors(method):
     Decorator that coerces `requests` library errors into appropriate `OnyxError` subclasses.
     """
     if inspect.isgeneratorfunction(method):
-
+        @functools.wraps(method)
         def wrapped_generator_method(self, *args, **kwargs):
             try:
                 yield from method(self, *args, **kwargs)
@@ -723,7 +724,7 @@ def onyx_errors(method):
 
         return wrapped_generator_method
     else:
-
+        @functools.wraps(method)
         def wrapped_method(self, *args, **kwargs):
             try:
                 return method(self, *args, **kwargs)


### PR DESCRIPTION
👋 Hi @tombch

Sorry for the unsolicited PR 🙂 . I noticed while working on the CLIMB-TRE docs that the help Jupyterlab shows (I expect it would be the same using the `help` builtin) isn't giving us useful docstrings, and instead just gives the docstring of the wrapper. This PR just uses `functools.wraps` to pass that info through. 

Here are screenshots of before and after

## Before

<img width="3004" height="2254" alt="before changes in this PR" src="https://github.com/user-attachments/assets/45f8cde9-0896-4e97-ab9a-b5dd8baab950" />

## After

<img width="3004" height="2254" alt="after changes in this PR" src="https://github.com/user-attachments/assets/0fc135ff-68ea-46b9-ba0e-01ea941dfe1f" />

It should also help suggest keyword arguments.